### PR TITLE
Add self-contained Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+bin/
+obj/
+.git/
+.gitignore
+.vscode/
+.idea/
+*.user
+*.suo
+*.cache
+*.log
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish -c ReleaseSC -r linux-x64 --self-contained true -o /out
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        ffmpeg \
+        imagemagick \
+        libgssapi-krb5-2 \
+        libicu72 \
+        libssl3 \
+        yt-dlp \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --system --uid 10001 --home /app --shell /usr/sbin/nologin webone
+
+WORKDIR /app
+COPY --from=build /out/ /app/
+RUN rm -f /app/webone.conf /app/codepage.conf /app/escargot.conf /app/openssl_webone.cnf
+
+RUN mkdir -p /etc/webone.conf.d /var/log \
+    && touch /var/log/webone.log /etc/webone.conf.d/ssl.crt /etc/webone.conf.d/ssl.key \
+    && chmod 666 /var/log/webone.log /etc/webone.conf.d/ssl.crt /etc/webone.conf.d/ssl.key \
+    && chown -R webone:webone /app /etc/webone.conf.d /var/log
+
+COPY --from=build /out/webone.conf /etc/webone.conf
+COPY --from=build /out/codepage.conf /etc/webone.conf.d/codepage.conf
+COPY --from=build /out/escargot.conf /etc/webone.conf.d/escargot.conf
+COPY --from=build /out/openssl_webone.cnf /etc/webone.conf.d/openssl_webone.cnf
+
+ENV OPENSSL_CONF=/etc/webone.conf.d/openssl_webone.cnf
+
+VOLUME ["/etc/webone.conf.d", "/var/log"]
+EXPOSE 8080
+
+USER webone
+ENTRYPOINT ["/app/webone"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,32 @@ The program is built using Microsoft .NET 8.0 SDK and [dotnet-packaging](https:/
 
 Windows developers can utilize `build.bat` script for cross-platform building. And there is similar `build.sh` script for Linux and macOS environments.
 
+## Docker
+The Dockerfile builds a self-contained Linux x64 binary and bundles runtime dependencies (ImageMagick, ffmpeg, yt-dlp).
+
+Build the image:
+```
+docker build -t webone:local .
+```
+
+Run the proxy (listening on port 8080):
+```
+docker run --rm -p 8080:8080 webone:local
+```
+
+Persist SSL keys and custom configuration by mounting `/etc/webone.conf.d` (this directory overrides the base `webone.conf`):
+```
+docker run --rm -p 8080:8080 \\
+  -v $(pwd)/webone.conf.d:/etc/webone.conf.d \\
+  -v $(pwd)/webone.log:/var/log/webone.log \\
+  webone:local
+```
+
+To use a custom config file, put it into `/etc/webone.conf.d` (e.g. `my.conf`) or pass it explicitly:
+```
+docker run --rm -p 8080:8080 webone:local /etc/webone.conf
+```
+
 ## Feedback
 Any questions can be written on official [VOGONS thread](https://www.vogons.org/viewtopic.php?f=24&t=67165), [phantom.sannata.ru thread](https://phantom.sannata.org/viewtopic.php?f=16&t=33291), and GitHub [Issues](https://github.com/atauenis/webone/issues) and [Discussions](https://github.com/atauenis/webone/discussions) tabs.
 


### PR DESCRIPTION
### Motivation

- Provide a reproducible, self-contained way to build and run WebOne in containers using the project's existing .NET build pipeline.
- Bundle common runtime tools (ImageMagick, `ffmpeg`, `yt-dlp`) so conversions work out-of-the-box in the container.
- Make it easy to persist configuration and SSL keys via a mounted `/etc/webone.conf.d` directory.
- Reduce Docker build context size with an appropriate `.dockerignore`.

### Description

- Add a multi-stage `Dockerfile` that uses the .NET 8 SDK to `dotnet publish` a self-contained `linux-x64` build and then packages it into a slim Debian runtime image with required packages installed.
- Create a `.dockerignore` to exclude build artifacts and editor/project files from the Docker build context.
- Update `README.md` with `Docker` instructions including `docker build -t webone:local .` and example `docker run` commands and guidance for mounting `/etc/webone.conf.d` and `/var/log`.
- Ensure the container creates `/etc/webone.conf.d`, default SSL key/cert placeholders, a `webone` system user, and exposes port `8080` with `ENTRYPOINT` set to `/app/webone`.

### Testing

- No automated tests were run as part of this change.
- The `Dockerfile` invokes `dotnet publish -c ReleaseSC -r linux-x64 --self-contained true` during image build as the project build step, tested only by static inspection.
- README examples for `docker build` and `docker run` were added but not executed in CI.
- The change includes no modifications to application logic and only adds packaging and documentation files (`Dockerfile`, `.dockerignore`, `README.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6962348dcc3c8331ba651f49365d7b2a)