### PR TITLE
Add docker-compose.yml example for running WebOne

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+
+services:
+  webone:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data/webone.conf.d:/etc/webone.conf.d
+      - ./data/webone.log:/var/log/webone.log
+    restart: unless-stopped


### PR DESCRIPTION
### Motivation
- Provide a ready-to-use `docker-compose.yml` to simplify running the WebOne Docker image.
- Make it straightforward to persist configuration and logs by mounting them under `./data` next to the YAML file.
- Align the repository with the existing Docker usage documented in `README.md` by offering a compose example.

### Description
- Add `docker-compose.yml` that defines a `webone` service which builds the image from the repository using `build: .`.
- Expose the application port with `ports: - "8080:8080"` so the proxy is reachable on the host.
- Mount persistent data into `./data` by mapping `./data/webone.conf.d` to `/etc/webone.conf.d` and `./data/webone.log` to `/var/log/webone.log`.
- Set a restart policy with `restart: unless-stopped` for basic resilience.

### Testing
- No automated tests were run for this documentation/configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696237cc05b48331b5e5e87f8a0638da)